### PR TITLE
Don't apply unnecessary patch

### DIFF
--- a/www-client/uzbl/uzbl-9999.ebuild
+++ b/www-client/uzbl/uzbl-9999.ebuild
@@ -22,8 +22,6 @@ DESCRIPTION="A web browser that adheres to the unix philosophy"
 LICENSE="GPL-2"
 
 SLOT="0"
-SRC_URI+=" https://patch-diff.githubusercontent.com/raw/uzbl/uzbl/pull/321.patch ->
-				${PN}-0.9.0-desktop_menu_entries.patch"
 
 KEYWORDS="~amd64 ~arm"
 
@@ -71,7 +69,6 @@ RDEPEND_A=( "${CDEPEND_A[@]}"
 inherit arrays
 
 src_prepare() {
-	eapply "${DISTDIR}/${PN}-0.9.0-desktop_menu_entries.patch"
 	xdg_src_prepare
 
 	# respect user CFLAGS


### PR DESCRIPTION
The patch that the ebuild was trying to apply was already applied and caused an error.