### PR TITLE
app-editors/mle: fix typo in ebuild

### DIFF
--- a/app-editors/mle/mle-1.1.ebuild
+++ b/app-editors/mle/mle-1.1.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
-inehrit rindeal
+inherit rindeal
 
 GH_RN="github:adsr"
 GH_REF="v${PV}"


### PR DESCRIPTION
`inehrit` -> `inherit`